### PR TITLE
Explicit set bus in play_stream for Godot 4.3. Web

### DIFF
--- a/addons/resonate/music_manager/stemmed_music_stream_player.gd
+++ b/addons/resonate/music_manager/stemmed_music_stream_player.gd
@@ -100,7 +100,7 @@ func start_stems(p_stems: Array, p_crossfade_time: float) -> void:
 		if length > max_length:
 			max_length = length
 		
-		var stream_id = playback.play_stream(stem.stream)
+		var stream_id = playback.play_stream(stem.stream, 0.0, 0.0, pitch_scale, playback_type, bus)
 		var max_volume = stem.volume
 		var volume = max_volume if stem.enabled else _DISABLED_VOLUME
 		


### PR DESCRIPTION
According to official docs, `play_stream` has new argument "bus" in 4.3.
- 4.3. https://docs.godotengine.org/en/stable/classes/class_audiostreamplaybackpolyphonic.html
- 4.2. https://docs.godotengine.org/en/4.2/classes/class_audiostreamplaybackpolyphonic.html

In 4.3, for some reason
- the desktop version still inherits bus from player (as in 4.2.)
- the web version uses Master bus if not set explicitly (new behaviour in 4.3.)

